### PR TITLE
Update SimpleCsvService.php

### DIFF
--- a/src/SimpleCsvService.php
+++ b/src/SimpleCsvService.php
@@ -103,6 +103,7 @@ class SimpleCsvService
     protected function closeFileObject(): void
     {
         $this->file = null;
+        $this->headers = null;
     }
 
     protected function writeLines($collection): void


### PR DESCRIPTION
When used successively in the same script to write multiple files, only the first one gets the headers included. Resetting the headers on closeFileObject() fix the issue.